### PR TITLE
Update PIXI method to use PIXI v5

### DIFF
--- a/dev/PixiApngAndGif.js
+++ b/dev/PixiApngAndGif.js
@@ -8103,7 +8103,7 @@
                 time: 0
             };
             // 循环执行器
-            _ts.ticker = new PIXI.ticker.Ticker();
+            _ts.ticker = new PIXI.Ticker();
             _ts.ticker.stop();
             // 精灵
             _ts.sprite = this.createSprite(esource, resources);
@@ -8131,7 +8131,7 @@
             // 为轮循执行器添加一个操作
             if (!_ts.temp.tickerIsAdd) {
                 _ts.ticker.add(function (deltaTime) {
-                    var elapsed = PIXI.ticker.shared.elapsedMS;
+                    var elapsed = PIXI.Ticker.shared.elapsedMS;
                     time += elapsed;
                     // 当帧停留时间已达到间隔帧率时播放下一帧
                     if (time > _ts.framesDelay[status.frame]) {
@@ -8290,7 +8290,7 @@
                 canvas.width = pngWidth;
                 canvas.height = pngHeight;
                 ctx = canvas.getContext('2d');
-                spriteSheet = new PIXI.BaseTexture.fromCanvas(canvas);
+                spriteSheet = new PIXI.BaseTexture.from(canvas);
                 imageData = ctx.createImageData(pngWidth, pngHeight);
                 imageData.data.set(data);
                 ctx.putImageData(imageData, 0, 0);
@@ -8323,7 +8323,7 @@
                 gif.decodeAndBlitFrameRGBA(i, imageData.data);
                 //将上面创建的图像数据放回到画面上
                 ctx.putImageData(imageData, 0, 0);
-                spriteSheet = new PIXI.BaseTexture.fromCanvas(canvas);
+                spriteSheet = new PIXI.BaseTexture.from(canvas);
                 obj.textures.push(new PIXI.Texture(spriteSheet, new PIXI.Rectangle(0, 0, gifWidth, gifHeight)));
             }
             // document.body.appendChild(canvas);

--- a/dev/demo.js
+++ b/dev/demo.js
@@ -8099,7 +8099,7 @@
                 time: 0
             };
             // 循环执行器
-            _ts.ticker = new PIXI.ticker.Ticker();
+            _ts.ticker = new PIXI.Ticker();
             _ts.ticker.stop();
             // 精灵
             _ts.sprite = this.createSprite(esource, resources);
@@ -8127,7 +8127,7 @@
             // 为轮循执行器添加一个操作
             if (!_ts.temp.tickerIsAdd) {
                 _ts.ticker.add(function (deltaTime) {
-                    var elapsed = PIXI.ticker.shared.elapsedMS;
+                    var elapsed = PIXI.Ticker.shared.elapsedMS;
                     time += elapsed;
                     // 当帧停留时间已达到间隔帧率时播放下一帧
                     if (time > _ts.framesDelay[status.frame]) {
@@ -8286,7 +8286,7 @@
                 canvas.width = pngWidth;
                 canvas.height = pngHeight;
                 ctx = canvas.getContext('2d');
-                spriteSheet = new PIXI.BaseTexture.fromCanvas(canvas);
+                spriteSheet = new PIXI.BaseTexture.from(canvas);
                 imageData = ctx.createImageData(pngWidth, pngHeight);
                 imageData.data.set(data);
                 ctx.putImageData(imageData, 0, 0);
@@ -8319,7 +8319,7 @@
                 gif.decodeAndBlitFrameRGBA(i, imageData.data);
                 //将上面创建的图像数据放回到画面上
                 ctx.putImageData(imageData, 0, 0);
-                spriteSheet = new PIXI.BaseTexture.fromCanvas(canvas);
+                spriteSheet = new PIXI.BaseTexture.from(canvas);
                 obj.textures.push(new PIXI.Texture(spriteSheet, new PIXI.Rectangle(0, 0, gifWidth, gifHeight)));
             }
             // document.body.appendChild(canvas);
@@ -8330,8 +8330,8 @@
 
     var app = new PIXI.Application();
     var loader = PIXI.loader, title = document.title, loadOption = {
-        loadType: PIXI.loaders.Resource.LOAD_TYPE.XHR,
-        xhrType: PIXI.loaders.Resource.XHR_RESPONSE_TYPE.BUFFER,
+        loadType: PIXI.LoaderResource.LOAD_TYPE.XHR,
+        xhrType: PIXI.LoaderResource.XHR_RESPONSE_TYPE.BUFFER,
         crossOrigin: ''
     }, imgs = {
         gif: 'http://isparta.github.io/compare/image/dongtai/gif/1.gif',

--- a/dev/index.html
+++ b/dev/index.html
@@ -25,9 +25,8 @@
     <button onclick="alert(apng.getDuration())">get Duration</button>
     <button onclick="alert(apng.getFramesLength())">get getFrames num</button>
     <hr>
-    
-    <!-- <script src="https://pixijs.download/v4.8.2/pixi.min.js"></script> -->
-    <script src="https://cdn.staticfile.org/pixi.js/4.8.2/pixi.min.js"></script>
+
+    <script src="https://cdn.staticfile.org/pixi.js/5.2.1/pixi.min.js"></script>
     <script src="./demo.js"></script>
 </body>
 </html>

--- a/src/PixiApngAndGif.es6
+++ b/src/PixiApngAndGif.es6
@@ -41,7 +41,7 @@ class Image{
         };
         
         // 循环执行器
-        _ts.ticker = new PIXI.ticker.Ticker();
+        _ts.ticker = new PIXI.Ticker();
         _ts.ticker.stop();
 
         // 精灵
@@ -79,7 +79,7 @@ class Image{
         // 为轮循执行器添加一个操作
         if(!_ts.temp.tickerIsAdd){
             _ts.ticker.add(deltaTime => {
-                let elapsed = PIXI.ticker.shared.elapsedMS;
+                let elapsed = PIXI.Ticker.shared.elapsedMS;
                 time+=elapsed;
 
                 // 当帧停留时间已达到间隔帧率时播放下一帧
@@ -293,7 +293,7 @@ class Image{
             canvas.width = pngWidth;
             canvas.height = pngHeight;
             ctx = canvas.getContext('2d');
-            spriteSheet = new PIXI.BaseTexture.fromCanvas(canvas);
+            spriteSheet = new PIXI.BaseTexture.from(canvas);
             
             imageData = ctx.createImageData(pngWidth,pngHeight);
             imageData.data.set(data);
@@ -351,7 +351,7 @@ class Image{
             //将上面创建的图像数据放回到画面上
             ctx.putImageData(imageData, 0, 0);
 
-            spriteSheet = new PIXI.BaseTexture.fromCanvas(canvas);
+            spriteSheet = new PIXI.BaseTexture.from(canvas);
             obj.textures.push(new PIXI.Texture(spriteSheet,new PIXI.Rectangle(0, 0, gifWidth, gifHeight)));
         };
         // document.body.appendChild(canvas);

--- a/src/demo.es6
+++ b/src/demo.es6
@@ -5,8 +5,8 @@ const app = new PIXI.Application();
 const loader = PIXI.loader,
     title = document.title,
     loadOption = {
-        loadType: PIXI.loaders.Resource.LOAD_TYPE.XHR,
-        xhrType: PIXI.loaders.Resource.XHR_RESPONSE_TYPE.BUFFER,
+        loadType: PIXI.LoaderResource.LOAD_TYPE.XHR,
+        xhrType: PIXI.LoaderResource.XHR_RESPONSE_TYPE.BUFFER,
         crossOrigin:''
     },
     imgs = {

--- a/src/index.html
+++ b/src/index.html
@@ -25,9 +25,8 @@
     <button onclick="alert(apng.getDuration())">get Duration</button>
     <button onclick="alert(apng.getFramesLength())">get getFrames num</button>
     <hr>
-    
-    <!-- <script src="https://pixijs.download/v4.8.2/pixi.min.js"></script> -->
-    <script src="https://cdn.staticfile.org/pixi.js/4.8.2/pixi.min.js"></script>
+
+    <script src="https://cdn.staticfile.org/pixi.js/5.2.1/pixi.min.js"></script>
     <script src="./demo.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Hello there are a lot api changes when migrating PIXI from V4 to V5. 

Could you check the PR please to update the library work with PIXI v5? As my company is recently upgrade to use V5 PIXI and we also want to keep using your library for playing GIFs in the canvas.

Thanks so much.